### PR TITLE
Fixes `AttributeError: reader`

### DIFF
--- a/moviepy/video/io/VideoFileClip.py
+++ b/moviepy/video/io/VideoFileClip.py
@@ -87,4 +87,7 @@ class VideoFileClip(VideoClip):
 
     def __del__(self):
       """ Close/delete the internal reader. """
-      del self.reader
+        try:
+            del self.reader
+        except AttributeError:
+            pass


### PR DESCRIPTION
I get the error

Exception ignored in: <bound method VideoFileClip.__del__ of <moviepy.video.io.VideoFileClip.VideoFileClip object at 0x10d347d30>>
Traceback (most recent call last):
File "/anaconda/lib/python3.5/site-packages/moviepy/video/io/VideoFileClip.py", line 89, in __del__
    del self.reader
AttributeError: reader

The error doesn't actually crash the program, but we don't need it